### PR TITLE
docs: show how to use optional options in the schema example

### DIFF
--- a/docs/feature-schema-validation.md
+++ b/docs/feature-schema-validation.md
@@ -62,7 +62,8 @@ app.put('/user/:id/password', checkSchema({
   },
   // Wildcards/dots for nested fields work as well
   'addresses.*.postalCode': {
-    optional: true,
+    // Make this field optional when undefined or null
+    optional: { options: { nullable: true } },
     isPostalCode: true
   }
 }), (req, res, next) => {


### PR DESCRIPTION
I am using the schema validation and was looking for `nullable` solution. I found in the doc https://express-validator.github.io/docs/validation-chain-api.html that `optional` has the `nullable` option but I did not know it should be under `options`. It took me for a while to figure it out. So, I think updating this doc might help other people in future.